### PR TITLE
Update log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,14 +71,14 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.11.1</version>
+			<version>2.17.1</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.13.2</version>
+			<version>2.17.1</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-log4j12 -->


### PR DESCRIPTION
Update the log4j version to fix several vulnerabilities (See https://logging.apache.org/log4j/2.x/security.html).